### PR TITLE
Bug fixes

### DIFF
--- a/src/scripts/contest.ts
+++ b/src/scripts/contest.ts
@@ -89,7 +89,9 @@ export async function getContests(page: Page): Promise<Contest[]> {
     optionEls.map(async (el) => el.textContent())
   ).then((options) =>
     // Remove the first option (empty) and the last option (new)
-    options.filter((option) => option !== 'new' && option !== '0')
+    options.filter(
+      (option) => option !== 'new' && option !== '0' && option !== '0*'
+    )
   );
   if (options.some((option) => option === undefined) || options.length === 2) {
     throw new ContestError(ContestMessages.NOT_FOUND);

--- a/src/scripts/problem.ts
+++ b/src/scripts/problem.ts
@@ -151,7 +151,7 @@ export async function getProblems(page: Page): Promise<Problem[]> {
     const row = rows.nth(i);
     const columns = await row.locator('td').all();
     const id = await columns[0].innerText();
-    problems.push(await getProblem(page, id));
+    problems.push(await getProblem(page, id.replace('(deleted)', '')));
   }
   return problems;
 }

--- a/src/scripts/site.ts
+++ b/src/scripts/site.ts
@@ -109,7 +109,7 @@ export async function getSites(page: Page): Promise<Site[]> {
     // Remove the last option (new)
     options.filter((option) => option !== 'new')
   );
-  if (options.some((option) => option === undefined) || options.length === 1) {
+  if (options.some((option) => option === undefined)) {
     throw new SiteError(SiteMessages.NOT_FOUND);
   }
   const sites: Site[] = [];


### PR DESCRIPTION
- getContests: Skip contest of id `0`;
- getProblems: Return all problems, including the deleted/disabled ones (`isEnabled`: `"No"`);
- getSites: Fix issue when contest has one single site (before threw a NOT_FOUND error);